### PR TITLE
Test Picker poisoning when try to call `Listener()` simultaneously with `PickAsync()`

### DIFF
--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomBalancer.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomBalancer.cs
@@ -1,0 +1,17 @@
+#if SUPPORT_LOAD_BALANCING
+using Grpc.Net.Client.Balancer;
+using Microsoft.Extensions.Logging;
+
+namespace Grpc.Tests.Shared;
+
+public class CustomBalancer(
+    IChannelControlHelper controller,
+    ILoggerFactory loggerFactory)
+    : SubchannelsLoadBalancer(controller, loggerFactory)
+{
+    protected override SubchannelPicker CreatePicker(IReadOnlyList<Subchannel> readySubchannels)
+    {
+        return new CustomPicker(readySubchannels);
+    }
+}
+#endif

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomBalancerFactory.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomBalancerFactory.cs
@@ -1,0 +1,15 @@
+#if SUPPORT_LOAD_BALANCING
+using Grpc.Net.Client.Balancer;
+
+namespace Grpc.Tests.Shared;
+
+public class CustomBalancerFactory : LoadBalancerFactory
+{
+    public override string Name => "test";
+
+    public override LoadBalancer Create(LoadBalancerOptions options)
+    {
+        return new CustomBalancer(options.Controller, options.LoggerFactory);
+    }
+}
+#endif

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomPicker.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomPicker.cs
@@ -1,0 +1,13 @@
+#if SUPPORT_LOAD_BALANCING
+using Grpc.Net.Client.Balancer;
+
+namespace Grpc.Tests.Shared;
+
+internal class CustomPicker(IReadOnlyList<Subchannel> subchannels) : SubchannelPicker
+{
+    public override PickResult Pick(PickContext context)
+    {
+        return PickResult.ForSubchannel(subchannels[Random.Shared.Next(0, subchannels.Count)]);
+    }
+}
+#endif

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomResolver.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomResolver.cs
@@ -1,0 +1,109 @@
+#if SUPPORT_LOAD_BALANCING
+using Grpc.Net.Client.Balancer;
+using Microsoft.Extensions.Logging;
+
+namespace Grpc.Tests.Shared;
+
+/// <summary>
+/// Test Resolver but a bit similar to really used in our project
+/// </summary>
+internal class CustomResolver(ILoggerFactory loggerFactory) : PollingResolver(loggerFactory)
+{
+    private const int AddressesUpdatePeriodMs = 500;
+
+    private static bool ShouldRenew = true;
+
+    // address lists should be different
+    private readonly string[][] _addresses = [
+        [ "test_addr_01", "test_addr_02" ],
+        [ "test_addr_03", "test_addr_04" ],
+    ];
+
+    private volatile int _updateAddressesIndex;
+    private Timer? _timer;
+    private readonly object _lock = new ();
+    private readonly object _lock2 = new ();
+
+    private ResolverResult _result = ResolverResult.ForResult([]);
+
+    protected override void OnStarted()
+    {
+        // periodically renew address lists
+        _timer = new Timer(
+            NotifyListenerAboutResolverResult,
+            null,
+            AddressesUpdatePeriodMs,
+            AddressesUpdatePeriodMs);
+
+        NotifyListenerAboutResolverResult();
+    }
+
+    public static void StopRenew()
+    {
+        ShouldRenew = false;
+    }
+
+    public static  void RestartRenew()
+    {
+        ShouldRenew = true;
+    }
+
+    protected override async Task ResolveAsync(CancellationToken cancellationToken)
+    {
+        await Task.Yield(); // fix used to avoid deadlock
+
+        lock (_lock)
+        {
+            Listener(_result);
+        }
+    }
+
+    private void NotifyListenerAboutResolverResult(object? state = null)
+    {
+        if (!ShouldRenew)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            UpdateResolverState();
+            Listener(_result);
+        }
+    }
+
+    // fill `_result` field with addresses we will use during the next `Listener()` call
+    private void UpdateResolverState()
+    {
+        var addresses = _addresses[_updateAddressesIndex];
+
+        var balancerAddresses = addresses
+            .Select(host => new BalancerAddress(host, 4242))
+            .ToArray();
+
+        _result = ResolverResult.ForResult(balancerAddresses);
+
+        if (_result.Addresses?.Count == 0)
+        {
+            return;
+        }
+
+        // choose next addresses list (or the first one if the end of the list is reached)
+        lock (_lock2)
+        {
+            Interlocked.Increment(ref _updateAddressesIndex);
+            Interlocked.CompareExchange(ref _updateAddressesIndex, 0, _addresses.Length);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        _timer?.Dispose();
+    }
+}
+#endif

--- a/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomResolverFactory.cs
+++ b/test/Grpc.Net.Client.Tests/Infrastructure/Balancer/CustomResolverFactory.cs
@@ -1,0 +1,15 @@
+#if SUPPORT_LOAD_BALANCING
+using Grpc.Net.Client.Balancer;
+
+namespace Grpc.Tests.Shared;
+
+public class CustomResolverFactory : ResolverFactory
+{
+    public override string Name => "test";
+
+    public override Resolver Create(ResolverOptions options)
+    {
+        return new CustomResolver(options.LoggerFactory);
+    }
+}
+#endif


### PR DESCRIPTION
This test shows situation when Picker become poisoned and cannot return valid pick results.

1. If picker user often enough there could be case when called `ConnectionManager.PickAsync(...)`, it started to execute and it calls `await ConnectionManager.GetPickerAsync(...)`.
2. `GetPickerAsync(...)` finishes execution, returns `_nextPickerTcs.Task.WaitAsync(...)` which then awaited inside `PickAsync(...)`.
3. Then before awaited task completed we have new balancer addresses (e.g. from service discovery) and we call `PollingResolver.Listener(...)` with new addresses. If addresses are really new then new subchannels will be created and at least one of them can get `TransientFailure` when trying to connect.
4. And if all of these cases happened (I mean when `Listener(...)` with new addresses called just after `GetPickerAsync(...)` returns but before returned task completed and one of sunchannels has `TransientFailure` state) then `Picker` become poisoned forever. It will always return `ErrorPicker` and `currentPicker.Pick(...).Type` will be `PickResultType.Fail`.

For this situation to happen there should be client side balancing enabled with custom resolver, `ConnectionManager.PickAsync(...)` calls should be often, connections should sometimes be broken. Even if it seems to be rare case nevertheless it happened often enough under high load and intensive use.